### PR TITLE
User Endpoints Refactoring

### DIFF
--- a/secretsauce/apps/account/serializers.py
+++ b/secretsauce/apps/account/serializers.py
@@ -6,3 +6,13 @@ class CompanySerializer(serializers.ModelSerializer):
     class Meta:
         model = Company
         fields = '__all__'
+
+class CustomUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        exclude = ['password', 'is_superuser', 'user_permissions', 'groups']
+
+class EditProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['first_name', 'last_name', 'phone']

--- a/secretsauce/apps/account/urls.py
+++ b/secretsauce/apps/account/urls.py
@@ -1,13 +1,13 @@
 from django.urls import path, include
 from secretsauce.apps.account import views
 
-# /users/ create user
+# /users/ create user or retrieve current user details (for non-admin) or user list (for admin)
 # /token/login/ obtain user authentication token (login)
 # /token/logout/ logout user, remove user authentication token
 
 # /users/activation/ activate user (currently not in use)
 # /users/resend_activation/ resend user activation email (currently not in use)
-# /users/me/ retrieve or update or delete the authenricated user
+# /users/<uuid:pk>/ retrieve or update or delete the authenticated user (only acccessible by admin user)
 # /users/set_password/ change user password
 # /users/reset_password/ send email to user with password reset link (need to setup PASSWORD_RESET_CONFIRM_URL)
 # /users/reset_password_confirm/ finish reset password process
@@ -16,6 +16,7 @@ from secretsauce.apps.account import views
 urlpatterns =[
     path('', include('djoser.urls')),
     path('', include('djoser.urls.authtoken')),
+    path('editprofile/', views.EditProfile.as_view(), name='edit_profile'),
     path('company/', views.CompanyList.as_view()),
     path('company/<uuid:pk>', views.CompanyDetail.as_view()),
     path('inviteuser/', views.InviteUser.as_view(), name='user_creation')

--- a/secretsauce/apps/account/views.py
+++ b/secretsauce/apps/account/views.py
@@ -56,3 +56,14 @@ class InviteUser(generics.CreateAPIView):
             }
             send_email('You have been invited to RMS Pricing Analytics Platform!', 'donotreply@rmsportal.com', [mappings['email']], '', 'create_user.html', mappings)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)        
+
+class EditProfile(APIView):
+    
+    def patch(self, request, format=None):
+        user = self.request.user
+        serializer = EditProfileSerializer(user, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+

--- a/secretsauce/settings.py
+++ b/secretsauce/settings.py
@@ -98,7 +98,14 @@ DJOSER = {
     'LOGIN_FIELD': 'email',
     'EMAIL_FIELD': 'email',
     'USER_CREATE_PASSWORD_RETYPE': True,
-    'PASSWORD_RESET_CONFIRM_URL': 'password-reset/confirm/{uid}/{token}'
+    'PASSWORD_RESET_CONFIRM_URL': 'password-reset/confirm/{uid}/{token}',
+    'SERIALIZERS':{
+        'user': 'secretsauce.apps.account.serializers.CustomUserSerializer',
+        'current_user': 'secretsauce.apps.account.serializers.CustomUserSerializer',
+    },
+    'PERMISSIONS':{
+        'user': ['rest_framework.permissions.IsAdminUser'],
+    },
 }
 
 WSGI_APPLICATION = 'secretsauce.wsgi.application'


### PR DESCRIPTION
### Context
- https://www.notion.so/Endpoints-for-editing-user-details-1205d82cc7794a528d5e2a581ea82030
- https://www.notion.so/Rewrite-User-serializer-for-frontend-8444e65ab0a6484eaad79c48b170361d

### Changes
- Added in 2 serializers:
  - `CustomUserSerializer` which returns more details than the default `UserSerializer`
![image](https://user-images.githubusercontent.com/39354695/87058939-48e44580-c23b-11ea-91ac-ddbf886e56ad.png)
  - `EditProfileSerializer` which allows for only `first_name`, `last_name` and `phone` fields
- Changed user endpoints permissions
   - for `/users/` endpoint, it can be used by admin to create user (although this is not actually used at all) or retrieve current user details (for non-admin) or user list (for admin)
   - for `/users/<uuid:pk>/` endpoint, only **admin** users can retrieve or update (those fields in `CustomUserSerializer`) or delete the authenticated user
- Added in new endpoint `/editprofile/` and new view `EditProfile` that can be called by all users whereby they can edit a few fields for their User Model
